### PR TITLE
Fix GiroCode parser without line CASH

### DIFF
--- a/app/src/main/java/li/klass/bezahlscanner/QrCodeTextParser.java
+++ b/app/src/main/java/li/klass/bezahlscanner/QrCodeTextParser.java
@@ -35,7 +35,7 @@ public class QrCodeTextParser {
 
     private Payment parseGirocode(String text) {
         String[] lines = text.split("[\r\n]");
-        if (lines.length < 11) {
+        if (lines.length < 10) {
             return null;
         }
 
@@ -51,15 +51,18 @@ public class QrCodeTextParser {
          CASH
 
          Test123
-
          */
+
+        // Field 'reason' after first empty line
+        int indexEmptyLine = Arrays.asList(lines).indexOf("");
+
         return new Payment.Builder()
                 .withDate(dateTimeProvider.now())
                 .withBic(lines[4])
                 .withName(lines[5])
                 .withIban(lines[6])
                 .withAmount(lines[7].replaceAll("[A-Za-z]+", ""))
-                .withReason(lines[10])
+                .withReason(lines[indexEmptyLine > 0 ? indexEmptyLine+1 : 10])
                 .build();
     }
 


### PR DESCRIPTION
I have an invoice with a QR-Code which has the following content:

```
BCD
001
2
SCT
AAAAAAAAXXX
Receipient
DE00000000000000000000
EUR10.00

REASON
```

Fix: The reason is set by the line after first empty line.
